### PR TITLE
UTC functions timezone fix

### DIFF
--- a/lib/js/bootstrap-datepicker.js
+++ b/lib/js/bootstrap-datepicker.js
@@ -450,10 +450,10 @@
 		},
 
 		_utc_to_local: function(utc){
-			return utc && new Date(utc.getTime() + (utc.getTimezoneOffset()*60000));
+			return utc && new Date(utc.getTime() - (utc.getTimezoneOffset()*60000));
 		},
 		_local_to_utc: function(local){
-			return local && new Date(local.getTime() - (local.getTimezoneOffset()*60000));
+			return local && new Date(local.getTime() + (local.getTimezoneOffset()*60000));
 		},
 		_zero_time: function(local){
 			return local && new Date(local.getFullYear(), local.getMonth(), local.getDate());


### PR DESCRIPTION
After debugging and checking Mozilla documentation, it turns out that the timezone symbol was switched for both UTC functions.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset

If the timezone is, for instance, GMT - 1, the offset returned by getTimezoneOffset is + 60 and with a GMT + 1, it is - 60.

It basically represents the offset compared to GMT + 0.
